### PR TITLE
Use macros provided by FindBison/FindFlex cmake module, oos builds.

### DIFF
--- a/GLSLCompiler/glslang/MachineIndependent/CMakeLists.txt
+++ b/GLSLCompiler/glslang/MachineIndependent/CMakeLists.txt
@@ -40,6 +40,8 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../
 	${CMAKE_CURRENT_SOURCE_DIR}/../OSDependent/Linux 
 	${CMAKE_CURRENT_SOURCE_DIR}/../../compiler
 	${PROJECT_SOURCE_DIR}/glsldb
+	${CMAKE_CURRENT_BINARY_DIR}
+	${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 add_library(glslang STATIC ${SRC} ${BISON_GLSLParser_OUTPUTS})

--- a/glsldb/CMakeLists.txt
+++ b/glsldb/CMakeLists.txt
@@ -38,6 +38,7 @@ include_directories(${OPENGL_INCLUDE_DIR}
 	${QT_INCLUDE_DIR}
 	${PROJECT_SOURCE_DIR}/GLSLCompiler/glslang/Public
 	${CMAKE_CURRENT_SOURCE_DIR}/utils
+	${CMAKE_CURRENT_BINARY_DIR}
 	${GLEW_INCLUDE_DIR}
 )
 


### PR DESCRIPTION
This pull request does a bit of code maintaince:
- Instead of manually calling the bison and flex executables it uses
  the macros provided by the FindFlex/FindBison modules.
- Allow to create out of source builds by adding or replacing some 
  search pathes to the include directories.
