### PR TITLE
fopen returns null on error so do not compare against -1

### DIFF
--- a/glsldb/utils/pfm.c
+++ b/glsldb/utils/pfm.c
@@ -197,7 +197,7 @@ int pfmWrite(const char *filename, PFMFile *pfmFile)
 	int dataSize;
 	FILE *fp;
 
-	if (!(fp = fopen(filename, "wb")) == -1) {
+	if (!(fp = fopen(filename, "wb"))) {
 		perror("opening image file failed");
 		return -1;
 	}


### PR DESCRIPTION
fopen returns null on error, so don't compare against -1