### PR TITLE
Don't consider debuggee exited on SIGCHLD

### DIFF
--- a/glsldb/progControl.cpp
+++ b/glsldb/progControl.cpp
@@ -288,6 +288,9 @@ pcErrorCode ProgramControl::checkChildStatus(void)
 		case SIGTRAP:
 			dbgPrint(DBGLVL_DEBUG, "debuggee process was stopped by SIGTRAP %i\n", signal);
 			return PCE_NONE;
+        case SIGCHLD:
+			dbgPrint(DBGLVL_DEBUG, "debuggee process was stopped by SIGCHLD %i\n", signal);
+			return PCE_NONE;
 		case SIGHUP:
 		case SIGINT:
 		case SIGQUIT:


### PR DESCRIPTION
Since `fork` itself is already is disregarded, it's a good idea to also disregard its very likely consequence: `SIGCHLD`. GLSL-Debugger isn't (and normally, shouldn't be) interested in the debuggee's children, so it should let it just handle their exiting normally. The signal isn't deadly if not handled by receiver, so nothing bad can happen.
This fixes #45 (which was considered duplicate), but not #15.