### PR TITLE
Don't consider debuggee exited on signals unused by debugger

### DIFF
--- a/glsldb/DebugLib/debuglib.h
+++ b/glsldb/DebugLib/debuglib.h
@@ -190,7 +190,8 @@ enum DBG_OPERATIONS {
 	DBG_CALL_ORIGFUNCTION,
 	/*
 	 Call the original function.
-	 Parameters: -
+	 Parameters:
+	 pendingSignal  : pending signal to deliver to debuggee
 	 Returns:
 	 result : DBG_ERROR_CODE
 	 */
@@ -471,6 +472,8 @@ typedef struct {
 	ALIGNED_DATA items[SHM_MAX_ITEMS];
 #ifdef _WIN32
 	ALIGNED_DATA isRecursing;
+#else
+	ALIGNED_DATA pendingSignal;
 #endif /* _WIN32 */
 } DbgRec;
 


### PR DESCRIPTION
After this commit the debuggee can handle any signal except `SIGSTOP` and `SIGTRAP`, which are used by GLSL-Debugger, and `SIGKILL` of course, — without confusing GLSL-Debugger.
This does work to solve #45 (by simply passing `SIGCHLD` to debuggee), but #15 is not addressed.