### PR TITLE
Fix #51 Online Help menu option broken

### DIFF
--- a/glsldb/mainWindow.cpp
+++ b/glsldb/mainWindow.cpp
@@ -379,7 +379,7 @@ void MainWindow::on_aAttach_triggered()
 
 void MainWindow::on_aOnlineHelp_triggered()
 {
-	QUrl url("http://www.vis.uni-stuttgart.de/glsldevil/");
+	QUrl url("https://glsl-debugger.github.io/");
 	QDesktopServices ds;
 	ds.openUrl(url);
 }


### PR DESCRIPTION
The menu option now points to https://glsl-debugger.github.io/. There isn't much "help" in that page but at least it exists.