### PR TITLE
Fix build with perl 5.26.

### DIFF
--- a/glsldb/DebugLib/generator/ArgSizeFuncs.pl
+++ b/glsldb/DebugLib/generator/ArgSizeFuncs.pl
@@ -32,6 +32,8 @@
 #
 ################################################################################
 
+use FindBin;
+use lib "$FindBin::Bin";
 
 require genTypes;
 require genTools;

--- a/glsldb/DebugLib/generator/BeginEndFunctionTest.pl
+++ b/glsldb/DebugLib/generator/BeginEndFunctionTest.pl
@@ -32,6 +32,9 @@
 #
 ################################################################################
 
+use FindBin;
+use lib "$FindBin::Bin";
+
 require genTypes;
 require genTools;
 our %regexps;

--- a/glsldb/DebugLib/generator/Enumerants.pl
+++ b/glsldb/DebugLib/generator/Enumerants.pl
@@ -27,6 +27,8 @@
 #
 ################################################################################
 
+use FindBin;
+use lib "$FindBin::Bin";
 
 use Getopt::Std;
 require genTools;

--- a/glsldb/DebugLib/generator/FunctionHooks.pl
+++ b/glsldb/DebugLib/generator/FunctionHooks.pl
@@ -32,6 +32,9 @@
 #
 ################################################################################
 
+use FindBin;
+use lib "$FindBin::Bin";
+
 use Getopt::Std;
 require prePostExecuteList;
 require genTools;

--- a/glsldb/DebugLib/generator/FunctionList.pl
+++ b/glsldb/DebugLib/generator/FunctionList.pl
@@ -31,6 +31,9 @@
 #
 ################################################################################
 
+use FindBin;
+use lib "$FindBin::Bin";
+
 require genTools;
 
 # edit this list for new extensions that include drawcalls

--- a/glsldb/DebugLib/generator/FunctionPointerTypes.pl
+++ b/glsldb/DebugLib/generator/FunctionPointerTypes.pl
@@ -32,6 +32,9 @@
 #
 ################################################################################
 
+use FindBin;
+use lib "$FindBin::Bin";
+
 require genTypes;
 require genTools;
 our %regexps;

--- a/glsldb/DebugLib/generator/GetProcAddressHook.pl
+++ b/glsldb/DebugLib/generator/GetProcAddressHook.pl
@@ -32,6 +32,8 @@
 #
 ################################################################################
 
+use FindBin;
+use lib "$FindBin::Bin";
 
 require genTools;
 our %regexps;

--- a/glsldb/DebugLib/generator/ReplayFunc.pl
+++ b/glsldb/DebugLib/generator/ReplayFunc.pl
@@ -32,6 +32,9 @@
 #
 ################################################################################
 
+use FindBin;
+use lib "$FindBin::Bin";
+
 require prePostExecuteList;
 require genTools;
 require genTypes;

--- a/glsldb/DebugLib/generator/Trampolines.pl
+++ b/glsldb/DebugLib/generator/Trampolines.pl
@@ -32,6 +32,9 @@
 #
 ################################################################################
 
+use FindBin;
+use lib "$FindBin::Bin";
+
 use Getopt::Std;
 require genTypes;
 require genTools;


### PR DESCRIPTION
Perl 5.26 removed "." from @INC.

Use FindBin to add the script directory to search path.