### PR TITLE
Issue 58: Remove explicit application styling to fix issue where tooltips are difficult to read.

### DIFF
--- a/glsldb/glsldb.cpp
+++ b/glsldb/glsldb.cpp
@@ -363,12 +363,6 @@ int main(int argc, char **argv)
 
 	QApplication app(argc, argv);
 
-#ifdef _WIN32
-	app.setStyle("windowsxp");
-#else /* _WIN32 */
-	app.setStyle("cleanlooks");
-#endif /* _WIN32 */
-
 	QCoreApplication::setOrganizationName("VIS");
 	QCoreApplication::setOrganizationDomain("vis.uni-stuttgart.de");
 	QCoreApplication::setApplicationName("glsldevil");


### PR DESCRIPTION
This change also lets the user open GLSL-Debugger using their own styles with qtconfig. (Later in Qt5 with the "-style" and "-stylesheet" options.)