### PR TITLE
Add missing include

### DIFF
--- a/GLSLCompiler/glslang/GenericCodeGen/CodeGen.cpp
+++ b/GLSLCompiler/glslang/GenericCodeGen/CodeGen.cpp
@@ -42,6 +42,7 @@
 #include <MachineIndependent/SymbolTable.h>
 #include <MachineIndependent/localintermediate.h>
 #include <MachineIndependent/ParseHelper.h>
+#include <locale.h>
 
 #include "CodeInsertion.h"
 #include "CodeTools.h"


### PR DESCRIPTION
Fixes use of undeclared identifier 'LC_NUMERIC' on OSX Mojave